### PR TITLE
TPD uses internal APIs in PDE that are no longer present in Photon #76

### DIFF
--- a/fr.obeo.releng.targetplatform.ui/META-INF/MANIFEST.MF
+++ b/fr.obeo.releng.targetplatform.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: fr.obeo.releng.targetplatform;visibility:=reexport,
  org.eclipse.equinox.p2.repository,
  org.eclipse.equinox.p2.core,
  org.eclipse.equinox.p2.metadata,
- org.eclipse.pde.core;bundle-version="3.8.0",
+ org.eclipse.pde.core;bundle-version="3.12.0",
  org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.xbase.lib

--- a/fr.obeo.releng.targetplatform.ui/src/fr/obeo/releng/targetplatform/ui/handler/PDEIntegration.java
+++ b/fr.obeo.releng.targetplatform.ui/src/fr/obeo/releng/targetplatform/ui/handler/PDEIntegration.java
@@ -39,7 +39,7 @@ public class PDEIntegration {
 
 	public PDEIntegration() {
 		service = Optional.fromNullable(
-			(ITargetPlatformService) PDECore.getDefault().acquireService(ITargetPlatformService.class.getName())
+			(ITargetPlatformService) PDECore.getDefault().acquireService(ITargetPlatformService.class)
 		);
 	}
 


### PR DESCRIPTION
Fixed internal call, raises minimum version number

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>